### PR TITLE
update for container image vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet build
 RUN dotnet publish --runtime alpine-x64 -c Release -o out --self-contained true /p:PublishTrimmed=true
 
 # build runtime image
-FROM cingulara/openrmf-base:1.04.00
+FROM cingulara/openrmf-base:1.08.02
 RUN apk update && apk upgrade
 
 RUN mkdir /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.01
+VERSION ?= 1.08.02
 NAME ?= "openrmf-msg-template"
 AUTHOR ?= "Dale Bingham"
 NO_CACHE ?= true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.00
+VERSION ?= 1.08.01
 NAME ?= "openrmf-msg-template"
 AUTHOR ?= "Dale Bingham"
 NO_CACHE ?= true

--- a/src/openrmf-msg-template.csproj
+++ b/src/openrmf-msg-template.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>openrmf_msg_template</RootNamespace>
     <ProjectGuid>{7f1b6279-9ce5-432d-82ef-70b91a1c1242}</ProjectGuid>
-    <Version>1.08.01</Version>
+    <Version>1.08.02</Version>
     <InformationalVersion>This is the OpenRMF OSS Application Template Messaging client for getting template XML/CKL files via messaging from Cingulara</InformationalVersion>
   </PropertyGroup>
 
@@ -16,6 +16,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/openrmf-msg-template.csproj
+++ b/src/openrmf-msg-template.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>openrmf_msg_template</RootNamespace>
     <ProjectGuid>{7f1b6279-9ce5-432d-82ef-70b91a1c1242}</ProjectGuid>
-    <Version>1.08.00</Version>
+    <Version>1.08.01</Version>
     <InformationalVersion>This is the OpenRMF OSS Application Template Messaging client for getting template XML/CKL files via messaging from Cingulara</InformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Commits on Aug 28, 2022
[update to latest base image](https://github.com/Cingulara/openrmf-msg-template/commit/23d2ef71b18eb1f9804405e13e491167211b625a)

Commits on Nov 27, 2022
[updating vulnerability information for v1.8.3](https://github.com/Cingulara/openrmf-msg-template/commit/d567bb910e5cd851f1ca3234f8dda93710cf7294)